### PR TITLE
Fixing "Elixir.isWatching is not a function" bug

### DIFF
--- a/browserify.js
+++ b/browserify.js
@@ -159,7 +159,7 @@ function loadConfig() {
         ],
 
         watchify: {
-            enabled: Elixir.isWatching(),
+            enabled: Elixir.isWatching,
 
             // https://www.npmjs.com/package/watchify#usage
             options: {}


### PR DESCRIPTION
Bug: running "gulp" or "gulp watch" caused a TypeError, and crashed.
Fix: Removing method call on line 162, referencing "isWatching" as a property instead.
